### PR TITLE
Add support for blog home page (page for posts)

### DIFF
--- a/includes/class-genesis-simple-sidebars-core.php
+++ b/includes/class-genesis-simple-sidebars-core.php
@@ -92,6 +92,18 @@ class Genesis_Simple_Sidebars_Core {
 
 		}
 
+		if ( is_home() ) {
+
+			$id = get_option('page_for_posts');
+
+			$sidebars = array(
+				'sidebar'      => genesis_get_custom_field( '_ss_sidebar', $id ),
+				'sidebar-alt'  => genesis_get_custom_field( '_ss_sidebar_alt', $id ),
+				'header-right' => genesis_get_custom_field( '_ss_header', $id ),
+			);
+
+		}
+
 		if ( is_tax() || is_category() || is_tag() ) {
 
 			$sidebars = array(


### PR DESCRIPTION
As simple as the title describes.
Currently when you set a page to be the blog home page (page for posts) this plugin doesn't work.
With this patch it will!