### PR TITLE
Ensure term fields are added after the PODS plugin registers terms

### DIFF
--- a/includes/class-genesis-simple-sidebars-term.php
+++ b/includes/class-genesis-simple-sidebars-term.php
@@ -4,7 +4,7 @@ class Genesis_Simple_Sidebars_Term {
 
 	public function init() {
 
-		add_action( 'init', array( $this, 'add_term_fields' ) );
+		add_action( 'init', array( $this, 'add_term_fields' ), 12 );
 
 	}
 


### PR DESCRIPTION
Fixes #34, where taxonomies created with the Pods plugin did not show the sidebar selection drop-down on the taxonomy admin settings page.

To test:

- Install [Pods](https://wordpress.org/plugins/pods/).
- Create a custom taxonomy.
- Create a custom post type that uses that taxonomy (select the taxonomy in Advanced Options -> Built-in Taxonomies).
- Add a new entry to your custom taxonomy.
- Edit that custom taxonomy and confirm the “Sidebar options” section appears.
