### PR TITLE
Allow sidebars to show in the custom Blog Posts page

### DIFF
--- a/includes/class-genesis-simple-sidebars-core.php
+++ b/includes/class-genesis-simple-sidebars-core.php
@@ -95,12 +95,14 @@ class Genesis_Simple_Sidebars_Core {
 
 		$sidebars = array();
 
-		if ( is_singular() ) {
+		if ( is_singular() || is_home() && isset( get_queried_object()->ID ) ) {
+
+			$post_id = get_queried_object()->ID;
 
 			$sidebars = array(
-				'sidebar'      => genesis_get_custom_field( '_ss_sidebar' ),
-				'sidebar-alt'  => genesis_get_custom_field( '_ss_sidebar_alt' ),
-				'header-right' => genesis_get_custom_field( '_ss_header' ),
+				'sidebar'      => genesis_get_custom_field( '_ss_sidebar', $post_id ),
+				'sidebar-alt'  => genesis_get_custom_field( '_ss_sidebar_alt', $post_id ),
+				'header-right' => genesis_get_custom_field( '_ss_header', $post_id ),
 			);
 
 		}


### PR DESCRIPTION
This PR brings the ability to show the sidebars when using a custom Blog Posts page set via `Settings->Reading`.

Steps to test:
 - Download this PR's version;
 - Create a new sidebar, add a few widgets to the sidebar;
 - Add/edit a blog posts page and set the new sidebar to that page;
 - Load the page and check if the sidebar is showing.

Closes #28