### PR TITLE
Fix for 5.4

### DIFF
--- a/includes/views/entry-metabox-content.php
+++ b/includes/views/entry-metabox-content.php
@@ -12,7 +12,7 @@ wp_nonce_field( 'genesis-simple-sidebars-save-entry', 'genesis-simple-sidebars-s
 if ( is_registered_sidebar( 'header-right' ) ) : ?>
 <p>
 	<label class="howto" for="genesis_simple_sidebars[_ss_header]"><span><?php echo esc_attr( $wp_registered_sidebars['header-right']['name'] ); ?><span></label>
-	<select name="genesis_simple_sidebars[_ss_header]" id="genesis_simple_sidebars[_ss_header]" style="width: 99%">
+	<select name="genesis_simple_sidebars[_ss_header]" id="genesis_simple_sidebars[_ss_header]">
 		<option value=""><?php esc_html_e( 'Default', 'genesis-simple-sidebars' ); ?></option>
 		<?php
 		foreach ( (array) $sidebars as $sidebar_id => $info ) {
@@ -28,7 +28,7 @@ if ( is_registered_sidebar( 'sidebar' ) ) :
 	?>
 <p>
 	<label class="howto" for="genesis_simple_sidebars[_ss_sidebar]"><span><?php echo esc_attr( $wp_registered_sidebars['sidebar']['name'] ); ?><span></label>
-	<select name="genesis_simple_sidebars[_ss_sidebar]" id="genesis_simple_sidebars[_ss_sidebar]" style="width: 99%">
+	<select name="genesis_simple_sidebars[_ss_sidebar]" id="genesis_simple_sidebars[_ss_sidebar]">
 		<option value=""><?php esc_html_e( 'Default', 'genesis-simple-sidebars' ); ?></option>
 		<?php
 		foreach ( (array) $sidebars as $sidebar_id => $info ) {
@@ -44,7 +44,7 @@ if ( is_registered_sidebar( 'sidebar-alt' ) ) :
 	?>
 <p>
 	<label class="howto" for="genesis_simple_sidebars[_ss_sidebar_alt]"><span><?php echo esc_attr( $wp_registered_sidebars['sidebar-alt']['name'] ); ?><span></label>
-	<select name="genesis_simple_sidebars[_ss_sidebar_alt]" id="genesis_simple_sidebars[_ss_sidebar_alt]" style="width: 99%">
+	<select name="genesis_simple_sidebars[_ss_sidebar_alt]" id="genesis_simple_sidebars[_ss_sidebar_alt]">
 		<option value=""><?php esc_html_e( 'Default', 'genesis-simple-sidebars' ); ?></option>
 		<?php
 		foreach ( (array) $sidebars as $sidebar_id => $info ) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: nathanrice, wpmuguru, marksabbath
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=5553118
 Tags: hooks, genesis, genesiswp, studiopress
 Requires at least: 4.7.3
-Tested up to: 5.2.2
+Tested up to: 5.4
 Stable tag: 2.2.1
 
 This plugin allows you to create multiple, dynamic widget areas, and assign those widget areas to sidebar locations within the Genesis Framework on a per post, per page, or per tag/category archive basis.


### PR DESCRIPTION
I tested this and all is working properly on 5.4. 

The only change I could see was that the dropdown was overlapping the sidebar:
<img width="323" alt="Screen Shot 2020-04-01 at 2 06 26 PM" src="https://user-images.githubusercontent.com/7538525/78171296-3c717500-7422-11ea-877b-15e51c2fbf1a.png">

## With the inline width removed it fits in the area:
<img width="290" alt="Screen Shot 2020-04-01 at 2 08 41 PM" src="https://user-images.githubusercontent.com/7538525/78171393-5ad77080-7422-11ea-856b-88cbf1e4373f.png">


