### PR TITLE
GF-1933 Git to SVN

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,15 +148,6 @@ workflows:
               only: /^\d+\.\d+\.\d+$/
             branches:
               ignore: /.*/
-      - hold:
-          type: approval
-          requires:
-            - checks
-          filters:
-            tags:
-              only: /^\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/
       - deploy_svn_tag:
           context: genesis-svn
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ commands:
       - run:
           command: |
             cd /tmp/artifacts
-            SLUG=grep 'Text Domain:' /tmp/src/plugin.php | awk -F: '{print $2}' | sed 's/^\s//'
+            SLUG=$(grep '@package' /tmp/src/plugin.php | awk -F ' ' '{print $3}' | sed 's/^\s//')
             svn co https://plugins.svn.wordpress.org/$SLUG --depth=empty .
             svn up trunk
             svn up tags --depth=empty
@@ -127,7 +127,6 @@ workflows:
       - deploy_svn_branch:
           context: genesis-svn
           requires:
-            - checkout
             - checks
           filters:
             branches:
@@ -140,7 +139,7 @@ workflows:
             tags:
               only: /^\d+\.\d+\.\d+$/
             branches:
-              only: master
+              ignore: /.*/
       - checks:
           requires:
             - checkout
@@ -148,14 +147,22 @@ workflows:
             tags:
               only: /^\d+\.\d+\.\d+$/
             branches:
-              only: master
-      - deploy_svn_tag:
-          context: genesis-svn
+              ignore: /.*/
+      - hold:
+          type: approval
           requires:
-            - checkout
             - checks
           filters:
             tags:
               only: /^\d+\.\d+\.\d+$/
             branches:
-              only: master
+              ignore: /.*/
+      - deploy_svn_tag:
+          context: genesis-svn
+          requires:
+            - hold
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ workflows:
       - deploy_svn_tag:
           context: genesis-svn
           requires:
-            - hold
+            - checks
           filters:
             tags:
               only: /^\d+\.\d+\.\d+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ commands:
       - deploy:
           command: |
             cd /tmp/artifacts
-            VERSION=grep 'Version:' /tmp/src/plugin.php | awk -F: '{print $2}' | sed 's/^\s//'
+            VERSION=$(grep 'Version:' /tmp/src/plugin.php | awk -F: '{print $2}' | sed 's/^\s//')
             svn cp trunk tags/$VERSION
   svn_commit:
     description: "Commit changes to SVN"
@@ -48,7 +48,7 @@ commands:
       - deploy:
           command: |
             cd /tmp/artifacts
-            VERSION=grep 'Version:' /tmp/src/plugin.php | awk -F: '{print $2}' | sed 's/^\s//'
+            VERSION=$(grep 'Version:' /tmp/src/plugin.php | awk -F: '{print $2}' | sed 's/^\s//')
             svn ci -m "Tagging $VERSION from Github" --no-auth-cache --non-interactive --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,10 +107,16 @@ workflows:
   version: 2
   checks:
     jobs:
-      - checkout
+      - checkout:
+          filters:
+            branches:
+              ignore: master
       - checks:
           requires:
             - checkout
+          filters:
+            branches:
+              ignore: master
 
   branch_deploy:
     jobs:


### PR DESCRIPTION
This PR adds an extra step to the `tag` deploy process which will require manual approval in CircleCI before changes are pushed to SVN.